### PR TITLE
Add link to reference documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A Matrix-Telegram hybrid puppeting/relaybot bridge.
 
 ### [Wiki](https://github.com/tulir/mautrix-telegram/wiki)
 
+### [Reference Documentation](https://docs.contour.so/kubesail/mautrix-telegram/getting-started)
+
+
 ### [Features & Roadmap](https://github.com/tulir/mautrix-telegram/blob/master/ROADMAP.md)
 
 ## Discussion


### PR DESCRIPTION
Hi there!

My name is Leo, a CS student at Brown building an automated platform for editable codebase documentation.

I generated documentation for this repository and placed a link in the README. Please feel free to try it out and let me know what you think!